### PR TITLE
Fix invalid IPv6 error

### DIFF
--- a/emlparser/emlparser.py
+++ b/emlparser/emlparser.py
@@ -1,6 +1,7 @@
 import base64
 import datetime
 import eml_parser
+import eml_parser.regex
 import json
 import os
 import re
@@ -29,9 +30,18 @@ class EmlParser(ServiceBase):
             return serial
 
     def execute(self, request):
-        parsed_eml = eml_parser.eml_parser.decode_email_b(request.file_contents,
-                                                          include_raw_body=True,
-                                                          include_attachment_data=True)
+        parser = eml_parser.eml_parser.EmlParser(include_raw_body=True, include_attachment_data=True)
+
+        # Validate URLs in sample, strip out [] if found
+        content_str = request.file_contents.decode(errors="ignore")
+        for u in eml_parser.regex.url_regex_simple.findall(content_str):
+            try:
+                urlparse(u)
+            except ValueError:
+                replacement = u.strip("[]")
+                content_str = content_str.replace(u, replacement, 1)
+        parsed_eml = parser.decode_email_bytes(content_str.encode())
+
         result = Result()
         header = parsed_eml['header']
 

--- a/emlparser/emlparser.py
+++ b/emlparser/emlparser.py
@@ -33,12 +33,11 @@ class EmlParser(ServiceBase):
         parser = eml_parser.eml_parser.EmlParser(include_raw_body=True, include_attachment_data=True)
 
         # Validate URLs in sample, strip out [] if found
+        invalid_chars = "[]"
         content_str = request.file_contents.decode(errors="ignore")
         for u in eml_parser.regex.url_regex_simple.findall(content_str):
-            try:
-                urlparse(u)
-            except ValueError:
-                replacement = u.strip("[]")
+            if any(c in u for c in invalid_chars):
+                replacement = u.strip(invalid_chars)
                 content_str = content_str.replace(u, replacement, 1)
         parsed_eml = parser.decode_email_bytes(content_str.encode())
 


### PR DESCRIPTION
Some URLs picked up in their regex includes "[]" characters which causes urllib.parse to freak out.

Replacing the URLs with those characters stripped solved the issue.