### PR TITLE
Remove null bytes in contents copy. Invalid urls should be caught by …

### DIFF
--- a/emlparser/emlparser.py
+++ b/emlparser/emlparser.py
@@ -32,14 +32,10 @@ class EmlParser(ServiceBase):
     def execute(self, request):
         parser = eml_parser.eml_parser.EmlParser(include_raw_body=True, include_attachment_data=True)
 
-        # Validate URLs in sample, strip out [] if found
-        invalid_chars = "[]"
-        content_str = request.file_contents.decode(errors="ignore")
-        for u in eml_parser.regex.url_regex_simple.findall(content_str):
-            if any(c in u for c in invalid_chars):
-                replacement = u.strip(invalid_chars)
-                content_str = content_str.replace(u, replacement, 1)
-        parsed_eml = parser.decode_email_bytes(content_str.encode())
+        content_str = request.file_contents
+        #Replace null bytes (wastes time during slices)
+        content_str = content_str.replace(b'\x00', b'')
+        parsed_eml = parser.decode_email_bytes(content_str)
 
         result = Result()
         header = parsed_eml['header']


### PR DESCRIPTION
…the library in latest version.

@cccs-kevin if there's a better solution to deal with excess null bytes, I'm all ears 😁

The problem is eml-parser uses a sliding window to process the contents, and the contents with what's in production are filled with null bytes affecting proper scaling of the service.