### PR TITLE
Outlook files will get converted before passed to eml_parser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM cccs/assemblyline-v4-service-base:latest AS base
 
 ENV SERVICE_PATH emlparser.emlparser.EmlParser
 
-USER assemblyline
+USER root
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir --user eml_parser && rm -rf ~/.cache/pip
+USER assemblyline
+RUN pip install -U --no-cache-dir --user eml_parser git+https://github.com/JoshData/convert-outlook-msg-file.git && rm -rf ~/.cache/pip
 
 # Clone Extract service code
 WORKDIR /opt/al_service

--- a/emlparser/emlparser.py
+++ b/emlparser/emlparser.py
@@ -1,19 +1,20 @@
 import base64
 import datetime
+import eml_parser
 import json
 import os
 import re
 import tempfile
-from tempfile import mkstemp
-from urllib.parse import urlparse
-
-import eml_parser
-import eml_parser.regex
 
 from assemblyline.odm import IP_ONLY_REGEX
 from assemblyline_v4_service.common.base import ServiceBase
 from assemblyline_v4_service.common.result import BODY_FORMAT, Result, ResultSection
 from assemblyline_v4_service.common.task import MaxExtractedExceeded
+from compoundfiles import CompoundFileInvalidMagicError
+from ipaddress import IPv4Address, ip_address
+from outlookmsgfile import load as convert_msg_eml
+from tempfile import mkstemp
+from urllib.parse import urlparse
 
 
 class EmlParser(ServiceBase):
@@ -34,8 +35,12 @@ class EmlParser(ServiceBase):
         parser = eml_parser.eml_parser.EmlParser(include_raw_body=True, include_attachment_data=True)
 
         content_str = request.file_contents
-        # Replace null bytes (wastes time during slices)
-        content_str = content_str.replace(b'\x00', b'')
+        try:
+            content_str = convert_msg_eml(request.file_path).as_bytes()
+        except CompoundFileInvalidMagicError:
+            # This isn't an Outlook file to be converted
+            pass
+
         parsed_eml = parser.decode_email_bytes(content_str)
 
         result = Result()
@@ -75,8 +80,8 @@ class EmlParser(ServiceBase):
 
             # Add Tags for received IPs
             if 'received_ip' in header:
-                for ip in header['received_ip']:
-                    kv_section.add_tag('network.static.ip', ip.strip())
+                [kv_section.add_tag('network.static.ip', ip.strip())
+                 for ip in header['received_ip'] if isinstance(ip_address(ip), IPv4Address)]
 
             # Add Tags for received Domains
             if 'received_domain' in header:

--- a/emlparser/emlparser.py
+++ b/emlparser/emlparser.py
@@ -33,16 +33,19 @@ class EmlParser(ServiceBase):
 
     def execute(self, request):
         parser = eml_parser.eml_parser.EmlParser(include_raw_body=True, include_attachment_data=True)
-
         content_str = request.file_contents
         try:
             content_str = convert_msg_eml(request.file_path).as_bytes()
         except CompoundFileInvalidMagicError:
-            # This isn't an Outlook file to be converted
-            pass
+            if 'office' in request.file_type:
+                # This Office file shouldn't be processed by an email parser
+                request.result = Result()
+                return
+            else:
+                # This isn't an Office file to be converted (least not with this tool)
+                pass
 
         parsed_eml = parser.decode_email_bytes(content_str)
-
         result = Result()
         header = parsed_eml['header']
 

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -2,7 +2,7 @@ name: EmlParser
 version: $SERVICE_TAG
 description: Parse emails using GOVCERT-LU eml_parser library while extracting header information, attachments, URIs...
 
-accepts: document/email
+accepts: document/email|document/office/unknown
 rejects: empty|metadata/.*
 
 stage: CORE


### PR DESCRIPTION
Related to: https://cccs.atlassian.net/browse/AL-1123

The service will attempt to convert submissions to eml, if the submission is not an Outlook file then the service will catch the specific exception and proceed to process as if it were an eml file.
