### PR TITLE
Handle streams containing msg files

### DIFF
--- a/emlparser/emlparser.py
+++ b/emlparser/emlparser.py
@@ -50,7 +50,7 @@ class EmlParser(ServiceBase):
             content_str = msg2eml(request.file_path).as_bytes()
         except CompoundFileInvalidMagicError:
             cs_hex = content_str.hex()
-            # Starts with a msg file header or container RootEntry within the file
+            # Starts with a msg file header or contains RootEntry within the file
             if cs_hex.startswith('E4 52 5C 7B 8C D8 A7 4D AE B1 53 78 D0 29'.replace(" ", "").lower()) or \
                     '52 00 6F 00 6F 00 74 00 20 00 45 00 6E 00 74 00 72 00 79'.replace(" ", "").lower() in cs_hex:
                 # OneNote file or extracted stream containing msg file. Extract service should pull these out.

--- a/emlparser/emlparser.py
+++ b/emlparser/emlparser.py
@@ -49,9 +49,12 @@ class EmlParser(ServiceBase):
         try:
             content_str = msg2eml(request.file_path).as_bytes()
         except CompoundFileInvalidMagicError:
-            if content_str.hex().startswith('E4 52 5C 7B 8C D8 A7 4D AE B1 53 78 D0 29'.replace(" ", "").lower()):
-                # OneNote file containing email content. Extract service should pull these out.
-                self.log.info('OneNote file contains email content. Did Extract pull them out?')
+            cs_hex = content_str.hex()
+            # Starts with a msg file header or container RootEntry within the file
+            if cs_hex.startswith('E4 52 5C 7B 8C D8 A7 4D AE B1 53 78 D0 29'.replace(" ", "").lower()) or \
+                    '52 00 6F 00 6F 00 74 00 20 00 45 00 6E 00 74 00 72 00 79'.replace(" ", "").lower() in cs_hex:
+                # OneNote file or extracted stream containing msg file. Extract service should pull these out.
+                self.log.info('File contains a MSG file. Did Extract pull them out?')
                 request.result = Result()
                 return
             else:


### PR DESCRIPTION
The service will ignore files that contain headers for MSG files but aren't actually MSG files. It will defer the responsibility of extraction to the Extract service.

The same technique used to extract MSG files from OneNote submissions can likely apply generically (pending implementation).