### PR TITLE
Bugfixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,12 @@ FROM cccs/assemblyline-v4-service-base:latest AS base
 
 ENV SERVICE_PATH emlparser.emlparser.EmlParser
 
+USER root
+RUN echo 'deb http://deb.debian.org/debian stretch-backports main' >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -y libemail-outlook-message-perl && rm -rf /var/lib/apt/lists/*
+
 USER assemblyline
-RUN pip install -U --no-cache-dir --user eml_parser compoundfiles compressed-rtf && rm -rf ~/.cache/pip
+RUN pip install -U --no-cache-dir --user eml_parser compoundfiles compressed-rtf mail-parser && rm -rf ~/.cache/pip
 
 # Clone Extract service code
 WORKDIR /opt/al_service

--- a/emlparser/convert_outlook/outlookmsgfile.py
+++ b/emlparser/convert_outlook/outlookmsgfile.py
@@ -108,7 +108,10 @@ class UNICODE(VariableLengthValueLoader):
         # value is a bytestring. I haven't seen specified what character encoding
         # is used when the Unicode storage type is not used, so we'll assume it's
         # ASCII or Latin-1 like but we'll use UTF-8 to cover the bases.
-        return value.decode("utf16")
+        try:
+            return value.decode("utf16")
+        except UnicodeDecodeError:
+            return value.decode("latin-1", 'replace')
 
 # TODO: The other variable-length tag types are "CLSID", "OBJECT".
 

--- a/emlparser/convert_outlook/outlookmsgfile.py
+++ b/emlparser/convert_outlook/outlookmsgfile.py
@@ -617,6 +617,12 @@ def load_message_stream(entry, is_top_level, doc):
     # Load stream data.
     props = None
     try:
+        if '__properties_version1.0' not in entry:
+            # Find nested directory within children
+            for child in entry:
+                if child.isdir and '__properties_version1.0' in child:
+                    entry = child
+                    break
         props = parse_properties(entry['__properties_version1.0'], is_top_level, entry, doc)
     except (KeyError, IndexError) as e:
         raise e

--- a/emlparser/convert_outlook/outlookmsgfile.py
+++ b/emlparser/convert_outlook/outlookmsgfile.py
@@ -19,7 +19,6 @@ import os
 import re
 import sys
 
-from builtins import isinstance
 from email.utils import formataddr, formatdate, parsedate_to_datetime
 from functools import reduce
 

--- a/emlparser/convert_outlook/outlookmsgfile.py
+++ b/emlparser/convert_outlook/outlookmsgfile.py
@@ -12,17 +12,19 @@
 # https://msdn.microsoft.com/en-us/library/ee157583(v=exchg.80).aspx
 # https://blogs.msdn.microsoft.com/openspecification/2009/11/06/msg-file-format-part-1/
 
-import compoundfiles
 import email.message
 import email.parser
 import email.policy
-import re
 import os
+import re
 import sys
 
-from email.utils import parsedate_to_datetime, formatdate, formataddr
-from compressed_rtf import decompress
+from builtins import isinstance
+from email.utils import formataddr, formatdate, parsedate_to_datetime
 from functools import reduce
+
+import compoundfiles
+from compressed_rtf import decompress
 
 
 # PROPERTY VALUE LOADERS
@@ -752,7 +754,7 @@ def process_attachment(msg, entry, doc):
         if isinstance(mime_type, bytes):
             mime_type = mime_type.decode("utf8")
 
-        filename = os.path.basename(filename)
+        filename = os.path.basename(filename) if filename else '<no_name_attachment>'
 
         # Python 3.6.
         if isinstance(blob, str):

--- a/emlparser/emlparser.py
+++ b/emlparser/emlparser.py
@@ -13,6 +13,7 @@ from assemblyline_v4_service.common.task import MaxExtractedExceeded
 
 from compoundfiles import CompoundFileInvalidMagicError
 from emlparser.convert_outlook.outlookmsgfile import load as msg2eml
+from mailparser.utils import msgconvert
 from ipaddress import IPv4Address, ip_address
 from tempfile import mkstemp
 from urllib.parse import urlparse
@@ -40,7 +41,12 @@ class EmlParser(ServiceBase):
         try:
             content_str = msg2eml(request.file_path).as_bytes()
         except CompoundFileInvalidMagicError:
+            # Not an Office file to be converted
             pass
+        except:
+            # Try using mailparser to convert
+            converted_path, _ = msgconvert(request.file_path)
+            content_str = open(converted_path, 'rb').read()
 
         parsed_eml = parser.decode_email_bytes(content_str)
         result = Result()


### PR DESCRIPTION
- Service will attempt to convert any submissions to eml using the Outlook -> EML conversion tool
- Fixed utf-16 decode error, same fix for utf-8 (decode using latin-1)
- Handle MAPIMessages, see: https://docs.microsoft.com/en-us/office/client-developer/outlook/mapi/mapi-messages
- If attachment doesn't have a name, give it a name