### PR TITLE
Parse email files exported as HTML

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN echo 'deb http://deb.debian.org/debian stretch-backports main' >> /etc/apt/s
 RUN apt-get update && apt-get install -y libemail-outlook-message-perl && rm -rf /var/lib/apt/lists/*
 
 USER assemblyline
-RUN pip install -U --no-cache-dir --user eml_parser compoundfiles compressed-rtf mail-parser && rm -rf ~/.cache/pip
+RUN pip install -U --no-cache-dir --user eml_parser compoundfiles compressed-rtf mail-parser bs4 lxml && rm -rf ~/.cache/pip
 
 # Clone Extract service code
 WORKDIR /opt/al_service

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -2,7 +2,7 @@ name: EmlParser
 version: $SERVICE_TAG
 description: Parse emails using GOVCERT-LU eml_parser library while extracting header information, attachments, URIs...
 
-accepts: document/email|document/office/email
+accepts: document/email|document/office/email|code/html
 rejects: empty|metadata/.*
 
 stage: CORE


### PR DESCRIPTION
Relating to: https://cccs.atlassian.net/browse/AL-1247

This would have to be expanded upon if there's different formats for HTML emails. This just covers one case if it was exported from a Microsoft application like Outlook.