### PR TITLE
Use lowercase to fit header filter forced case

### DIFF
--- a/emlparser/emlparser.py
+++ b/emlparser/emlparser.py
@@ -60,7 +60,7 @@ class EmlParser(ServiceBase):
             headers = {}
             headers_key_lowercase = []
             for k, v in msg.header.items():
-                if k in self.header_filter or v is None or v == "":
+                if k.lower() in self.header_filter or v is None or v == "":
                     continue
                 # Some headers are repeating, like 'Received'
                 if k in headers:
@@ -173,7 +173,7 @@ class EmlParser(ServiceBase):
             # Specialized fields
             if (
                 msg.namedProperties.get(("851F", extract_msg.constants.PSETID_COMMON))
-                and msg.namedProperties.get(("851F", extract_msg.constants.PSETID_COMMON)).startswith("\\")
+                and msg.namedProperties.get(("851F", extract_msg.constants.PSETID_COMMON)).startswith("\\\\")
             ):
                 plrfp = msg.namedProperties.get(("851F", extract_msg.constants.PSETID_COMMON))
                 heur_section = ResultKeyValueSection("CVE-2023-23397", parent=attributes_section)

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -47,4 +47,5 @@ heuristics:
 docker_config:
   image: ${REGISTRY}cccs/assemblyline-service-emlparser:$SERVICE_TAG
   cpu_cores: 1
-  ram_mb: 256
+  ram_mb_min: 256
+  ram_mb: 2048


### PR DESCRIPTION
Force lowercase key comparison for outlook files since the header filter list is forced lowercase. Will keep it lowercase to be able to reuse the same list across the two libraries that are not returning the keys with the same casing (eml/outlook). 
Issue raised: CybercentreCanada/assemblyline/issues/61